### PR TITLE
Warning fixes and muls libc compatibility

### DIFF
--- a/libtuxtxt/libtuxtxt.c
+++ b/libtuxtxt/libtuxtxt.c
@@ -18,12 +18,6 @@
  *                                                                            *
  ******************************************************************************/
 
-#ifdef DEBUG
-#undef DEBUG
-#endif
-
-#define DEBUG 0
-
 #include <sys/ioctl.h>
 #include <fcntl.h>
 

--- a/libtuxtxt/libtuxtxt.c
+++ b/libtuxtxt/libtuxtxt.c
@@ -38,7 +38,12 @@
  ******************************************************************************/
 
 static int tuxtxt_initialized=0;
+
+#ifdef __GLIBC__
 static pthread_mutex_t tuxtxt_control_lock = PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP;
+#else
+static pthread_mutex_t tuxtxt_control_lock = {{PTHREAD_MUTEX_RECURSIVE}};
+#endif
 static pthread_mutex_t tuxtxt_key_queue_lock = PTHREAD_MUTEX_INITIALIZER;
 
 int tuxtxt_init()

--- a/libtuxtxt/tuxtxt_common.h
+++ b/libtuxtxt/tuxtxt_common.h
@@ -4346,7 +4346,7 @@ void tuxtxt_RenderCharIntern(tstRenderInfo* renderinfo,int Char, tstPageAttr *At
 		for (Row = he; Row; Row--) /* row counts up, but down may be a little faster :) */
 		{
 			int pixtodo = (renderinfo->usettf ? renderinfo->sbit->width : curfontwidth);
-			char *pstart = p;
+			unsigned char *pstart = p;
 
 			for (Bit = xfactor * (renderinfo->sbit->left + renderinfo->TTFShiftX); Bit > 0; Bit--) /* fill left margin */
 			{

--- a/libtuxtxt/tuxtxt_common.h
+++ b/libtuxtxt/tuxtxt_common.h
@@ -23,6 +23,8 @@
 
 #include <linux/input.h>
 
+void writeproc(const char* dest, const char *value);
+
 const char *ObjectSource[] =
 {
 	"(illegal)",

--- a/tuxtxt/tuxtxt.c
+++ b/tuxtxt/tuxtxt.c
@@ -264,7 +264,7 @@ int tuxtxt_run_ui(int pid, int demux)
 	if (tuxtxt_cache.vtxtpid == -1 || renderinfo.fb == -1 || renderinfo.sx == -1 || renderinfo.ex == -1 || renderinfo.sy == -1 || renderinfo.ey == -1)
 	{
 		printf("TuxTxt <Invalid Param(s)>\n");
-		return;
+		return -1;
 	}
 
 	/* initialisations */
@@ -274,7 +274,7 @@ int tuxtxt_run_ui(int pid, int demux)
 			tuxtxt_close();
 		}
 #endif
-		return;
+		return 0;
 	}
 	
 	/* main loop */

--- a/tuxtxt/tuxtxt.h
+++ b/tuxtxt/tuxtxt.h
@@ -40,6 +40,7 @@
 #include <string.h>
 #include <unistd.h>
 #include <sys/types.h>
+#include <sys/stat.h>
 #include <sys/time.h>
 #include <ctype.h>
 


### PR DESCRIPTION
DISTRO should disable debug on configure step  in libtuxtxt.bb:

remove EXTRA_OECONF = "--with-boxtype=generic DVB_API_VERSION=5"
and add EXTRA_OECONF = "--with-boxtype=generic DVB_API_VERSION=5 --without-debug"
